### PR TITLE
Normalize ingredient quantity parsing and display

### DIFF
--- a/backend/src/services/recipeExtractionService.js
+++ b/backend/src/services/recipeExtractionService.js
@@ -4,6 +4,7 @@ const cheerio = require('cheerio');
 const crypto = require('crypto');
 const pool = require('../config/database');
 const logger = require('../config/logger');
+const { parseIngredientString: parseIngredient } = require('../utils/ingredientParser');
 
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY,
@@ -280,52 +281,11 @@ function parseSchemaInstructions(instructions) {
 }
 
 /**
- * Basic ingredient string parsing
+ * Parse ingredient string using the new robust parser
+ * This wrapper maintains the same interface for backward compatibility
  */
 function parseIngredientString(rawText, sortOrder = 0) {
-  // This is a simplified parser - in production, consider using an LLM or specialized library
-  const pattern = /^(\d+\/\d+|\d+\.?\d*)\s*([a-zA-Z]+)?\s+(.+?)(?:,\s*(.+))?$/i;
-  const match = rawText.match(pattern);
-
-  if (match) {
-    return {
-      rawText,
-      sortOrder,
-      quantity: parseQuantity(match[1]),
-      unit: match[2] || null,
-      ingredient: match[3].trim(),
-      preparation: match[4] || null,
-      group: null,
-    };
-  }
-
-  // Fallback: just store the raw text
-  return {
-    rawText,
-    sortOrder,
-    quantity: null,
-    unit: null,
-    ingredient: rawText,
-    preparation: null,
-    group: null,
-  };
-}
-
-/**
- * Parse quantity (handles fractions)
- */
-function parseQuantity(quantityStr) {
-  if (!quantityStr) {
-    return null;
-  }
-
-  // Handle fractions like "1/2"
-  if (quantityStr.includes('/')) {
-    const [numerator, denominator] = quantityStr.split('/').map(Number);
-    return numerator / denominator;
-  }
-
-  return parseFloat(quantityStr);
+  return parseIngredient(rawText, sortOrder);
 }
 
 /**

--- a/backend/src/utils/ingredientParser.js
+++ b/backend/src/utils/ingredientParser.js
@@ -1,0 +1,499 @@
+/**
+ * Ingredient Parsing & Normalization Utility
+ *
+ * Parses ingredient strings into structured data:
+ * - quantity (number)
+ * - unit (normalized string)
+ * - ingredient (name)
+ * - preparation (optional method like "chopped", "diced")
+ * - originalText (raw input for fallback)
+ *
+ * Handles:
+ * - Unicode fractions (½, ¼, ⅓, etc.)
+ * - Mixed numbers (1 1/2, 2 ½)
+ * - Ranges (2-3, 2 to 3)
+ * - Unit synonyms (tablespoon → tbsp, pounds → lb)
+ * - Unitless ingredients (2 eggs, salt to taste)
+ */
+
+/**
+ * Unicode fraction to decimal mapping
+ */
+const UNICODE_FRACTIONS = {
+  '½': 0.5,
+  '⅓': 0.333,
+  '⅔': 0.666,
+  '¼': 0.25,
+  '¾': 0.75,
+  '⅕': 0.2,
+  '⅖': 0.4,
+  '⅗': 0.6,
+  '⅘': 0.8,
+  '⅙': 0.166,
+  '⅚': 0.833,
+  '⅛': 0.125,
+  '⅜': 0.375,
+  '⅝': 0.625,
+  '⅞': 0.875,
+};
+
+/**
+ * Unit normalization map - maps various spellings to standard abbreviations
+ */
+const UNIT_MAP = {
+  // Volume - teaspoon
+  teaspoon: 'tsp',
+  teaspoons: 'tsp',
+  tsp: 'tsp',
+  tsps: 'tsp',
+  t: 'tsp',
+
+  // Volume - tablespoon
+  tablespoon: 'tbsp',
+  tablespoons: 'tbsp',
+  tbsp: 'tbsp',
+  tbsps: 'tbsp',
+  tbs: 'tbsp',
+  T: 'tbsp',
+  Tbsp: 'tbsp',
+  Tbs: 'tbsp',
+
+  // Volume - cup
+  cup: 'cup',
+  cups: 'cup',
+  c: 'cup',
+  C: 'cup',
+
+  // Volume - fluid ounce
+  'fluid ounce': 'fl oz',
+  'fluid ounces': 'fl oz',
+  'fl oz': 'fl oz',
+  floz: 'fl oz',
+
+  // Volume - pint/quart/gallon
+  pint: 'pint',
+  pints: 'pint',
+  pt: 'pint',
+  quart: 'quart',
+  quarts: 'quart',
+  qt: 'quart',
+  gallon: 'gallon',
+  gallons: 'gallon',
+  gal: 'gallon',
+
+  // Volume - metric
+  milliliter: 'ml',
+  milliliters: 'ml',
+  ml: 'ml',
+  mL: 'ml',
+  liter: 'l',
+  liters: 'l',
+  l: 'l',
+  L: 'l',
+
+  // Weight - imperial
+  pound: 'lb',
+  pounds: 'lb',
+  lb: 'lb',
+  lbs: 'lb',
+  ounce: 'oz',
+  ounces: 'oz',
+  oz: 'oz',
+
+  // Weight - metric
+  gram: 'g',
+  grams: 'g',
+  g: 'g',
+  kilogram: 'kg',
+  kilograms: 'kg',
+  kg: 'kg',
+
+  // Count/container units
+  piece: 'piece',
+  pieces: 'piece',
+  whole: 'whole',
+  large: 'large',
+  medium: 'medium',
+  small: 'small',
+  can: 'can',
+  cans: 'can',
+  package: 'package',
+  packages: 'package',
+  pkg: 'package',
+  jar: 'jar',
+  jars: 'jar',
+  bottle: 'bottle',
+  bottles: 'bottle',
+  box: 'box',
+  boxes: 'box',
+  bag: 'bag',
+  bags: 'bag',
+  bunch: 'bunch',
+  bunches: 'bunch',
+  head: 'head',
+  heads: 'head',
+  clove: 'clove',
+  cloves: 'clove',
+  slice: 'slice',
+  slices: 'slice',
+  stalk: 'stalk',
+  stalks: 'stalk',
+  stick: 'stick',
+  sticks: 'stick',
+  sprig: 'sprig',
+  sprigs: 'sprig',
+  pinch: 'pinch',
+  pinches: 'pinch',
+  dash: 'dash',
+  dashes: 'dash',
+  handful: 'handful',
+  handfuls: 'handful',
+};
+
+/**
+ * Words that are NOT units but might look like them
+ * These should be treated as part of the ingredient name
+ */
+const NON_UNIT_WORDS = new Set([
+  'and',
+  'or',
+  'of',
+  'to',
+  'for',
+  'with',
+  'fresh',
+  'dried',
+  'ground',
+  'chopped',
+  'minced',
+  'diced',
+  'sliced',
+  'grated',
+  'shredded',
+  'crushed',
+  'melted',
+  'softened',
+  'room',
+  'temperature',
+  'cold',
+  'warm',
+  'hot',
+  'cooked',
+  'raw',
+  'ripe',
+  'unripe',
+  'peeled',
+  'seeded',
+  'pitted',
+  'boneless',
+  'skinless',
+  'lean',
+  'extra',
+  'virgin',
+  'light',
+  'dark',
+  'sweet',
+  'unsweetened',
+  'salted',
+  'unsalted',
+  'plain',
+  'all',
+  'purpose',
+  'self',
+  'rising',
+  'active',
+  'dry',
+  'instant',
+  'quick',
+  'rolled',
+  'steel',
+  'cut',
+  'old',
+  'fashioned',
+  'taste',
+]);
+
+/**
+ * Normalize a unit string to its standard abbreviation
+ * @param {string} unit - Raw unit string
+ * @returns {string|null} Normalized unit or null if not a known unit
+ */
+function normalizeUnit(unit) {
+  if (!unit) return null;
+
+  const lower = unit.toLowerCase().trim();
+
+  // Check if it's a non-unit word
+  if (NON_UNIT_WORDS.has(lower)) {
+    return null;
+  }
+
+  return UNIT_MAP[lower] || UNIT_MAP[unit] || null;
+}
+
+/**
+ * Parse a quantity string into a number
+ * Handles fractions, mixed numbers, ranges, and Unicode fractions
+ *
+ * @param {string} quantityStr - Raw quantity string
+ * @returns {number|null} Parsed numeric value or null
+ */
+function parseQuantity(quantityStr) {
+  if (!quantityStr) return null;
+
+  let str = String(quantityStr).trim();
+
+  // Replace Unicode fractions with decimals
+  for (const [frac, decimal] of Object.entries(UNICODE_FRACTIONS)) {
+    if (str.includes(frac)) {
+      // Handle mixed numbers like "1½" or "1 ½"
+      const mixedMatch = str.match(new RegExp(`(\\d+)\\s*${frac}`));
+      if (mixedMatch) {
+        return parseInt(mixedMatch[1], 10) + decimal;
+      }
+      // Just the fraction
+      if (str === frac) {
+        return decimal;
+      }
+      str = str.replace(frac, String(decimal));
+    }
+  }
+
+  // Handle text fractions like "1/2" or "1 1/2"
+  const mixedFractionMatch = str.match(/^(\d+)\s+(\d+)\/(\d+)$/);
+  if (mixedFractionMatch) {
+    const whole = parseInt(mixedFractionMatch[1], 10);
+    const numerator = parseInt(mixedFractionMatch[2], 10);
+    const denominator = parseInt(mixedFractionMatch[3], 10);
+    return whole + numerator / denominator;
+  }
+
+  // Handle simple fractions like "1/2"
+  const fractionMatch = str.match(/^(\d+)\/(\d+)$/);
+  if (fractionMatch) {
+    return parseInt(fractionMatch[1], 10) / parseInt(fractionMatch[2], 10);
+  }
+
+  // Handle ranges like "2-3" or "2 to 3" or "2 or 3" - take the average
+  const rangeMatch = str.match(/^(\d+\.?\d*)\s*(?:-|to|or)\s*(\d+\.?\d*)$/i);
+  if (rangeMatch) {
+    return (parseFloat(rangeMatch[1]) + parseFloat(rangeMatch[2])) / 2;
+  }
+
+  // Handle simple decimals or integers
+  const numberMatch = str.match(/^(\d+\.?\d*)$/);
+  if (numberMatch) {
+    return parseFloat(numberMatch[1]);
+  }
+
+  return null;
+}
+
+/**
+ * Parse an ingredient string into structured components
+ *
+ * @param {string} rawText - The complete ingredient line
+ * @param {number} [sortOrder=0] - Optional sort order
+ * @returns {Object} Parsed ingredient object
+ */
+function parseIngredientString(rawText, sortOrder = 0) {
+  if (!rawText || typeof rawText !== 'string') {
+    return {
+      rawText: rawText || '',
+      sortOrder,
+      quantity: null,
+      unit: null,
+      ingredient: rawText || '',
+      preparation: null,
+      group: null,
+    };
+  }
+
+  const original = rawText.trim();
+
+  // First, try to split by comma for preparation notes
+  // e.g., "2 cups flour, sifted" → ingredient: "flour", preparation: "sifted"
+  let mainPart = original;
+  let preparation = null;
+
+  const commaIndex = original.indexOf(',');
+  if (commaIndex > 0) {
+    mainPart = original.substring(0, commaIndex).trim();
+    preparation = original.substring(commaIndex + 1).trim();
+  }
+
+  // Also check for parenthetical notes
+  const parenMatch = mainPart.match(/^(.+?)\s*\(([^)]+)\)\s*$/);
+  if (parenMatch) {
+    mainPart = parenMatch[1].trim();
+    preparation = preparation ? `${parenMatch[2]}, ${preparation}` : parenMatch[2];
+  }
+
+  // Build regex pattern for quantity detection
+  // Matches: numbers, fractions, mixed numbers, Unicode fractions, ranges
+  const quantityPattern =
+    /^(\d+\s+\d+\/\d+|\d+\/\d+|\d+\.?\d*\s*[½⅓⅔¼¾⅕⅖⅗⅘⅙⅚⅛⅜⅝⅞]|[½⅓⅔¼¾⅕⅖⅗⅘⅙⅚⅛⅜⅝⅞]|\d+\.?\d*(?:\s*(?:-|to|or)\s*\d+\.?\d*)?)\s*/i;
+
+  const quantityMatch = mainPart.match(quantityPattern);
+
+  let quantity = null;
+  let remainingText = mainPart;
+
+  if (quantityMatch) {
+    quantity = parseQuantity(quantityMatch[1]);
+    remainingText = mainPart.substring(quantityMatch[0].length).trim();
+  }
+
+  // Now try to extract unit from the remaining text
+  // Look for the first word that might be a unit
+  let unit = null;
+  let ingredientName = remainingText;
+
+  // Split remaining text into words
+  const words = remainingText.split(/\s+/);
+
+  if (words.length > 0) {
+    // Check if first word is a unit
+    const normalizedUnit = normalizeUnit(words[0]);
+    if (normalizedUnit) {
+      unit = normalizedUnit;
+      ingredientName = words.slice(1).join(' ').trim();
+    }
+    // Special case: "fluid ounce" is two words
+    else if (words.length > 1 && words[0].toLowerCase() === 'fluid' && words[1].toLowerCase().startsWith('oz')) {
+      unit = 'fl oz';
+      ingredientName = words.slice(2).join(' ').trim();
+    }
+  }
+
+  // Clean up ingredient name
+  // Remove leading "of" (e.g., "cup of flour" → "flour")
+  if (ingredientName.toLowerCase().startsWith('of ')) {
+    ingredientName = ingredientName.substring(3).trim();
+  }
+
+  // If we still don't have an ingredient name, use the whole original text
+  if (!ingredientName) {
+    ingredientName = original;
+  }
+
+  return {
+    rawText: original,
+    sortOrder,
+    quantity,
+    unit,
+    ingredient: ingredientName,
+    preparation,
+    group: null,
+  };
+}
+
+/**
+ * Format an ingredient for display: quantity unit ingredient
+ *
+ * @param {Object} ingredient - Parsed ingredient object
+ * @returns {string} Formatted display string
+ */
+function formatIngredientDisplay(ingredient) {
+  if (!ingredient) return '';
+
+  const { quantity, unit, ingredient: name, rawText } = ingredient;
+
+  // If no parsed data, return raw text
+  if (quantity === null && !unit && (!name || name === rawText)) {
+    return rawText || '';
+  }
+
+  const parts = [];
+
+  // Format quantity with fractions
+  if (quantity !== null) {
+    parts.push(formatQuantityDisplay(quantity));
+  }
+
+  // Add unit if present
+  if (unit) {
+    parts.push(unit);
+  }
+
+  // Add ingredient name
+  if (name && name !== rawText) {
+    parts.push(name);
+  } else if (!parts.length) {
+    // Fallback to raw text if nothing else
+    return rawText || '';
+  }
+
+  return parts.join(' ').trim();
+}
+
+/**
+ * Format a numeric quantity for display, converting to fractions where appropriate
+ *
+ * @param {number} quantity - Numeric quantity
+ * @returns {string} Formatted quantity string
+ */
+function formatQuantityDisplay(quantity) {
+  if (quantity === null || quantity === undefined) return '';
+
+  const whole = Math.floor(quantity);
+  const remainder = quantity - whole;
+
+  // Common fractions with their Unicode equivalents
+  const fractionMap = [
+    [0.125, '⅛'],
+    [0.25, '¼'],
+    [0.333, '⅓'],
+    [0.375, '⅜'],
+    [0.5, '½'],
+    [0.625, '⅝'],
+    [0.666, '⅔'],
+    [0.75, '¾'],
+    [0.875, '⅞'],
+  ];
+
+  // Find closest fraction
+  let closestFrac = null;
+  let minDiff = Infinity;
+
+  for (const [value, symbol] of fractionMap) {
+    const diff = Math.abs(remainder - value);
+    if (diff < minDiff && diff < 0.05) {
+      minDiff = diff;
+      closestFrac = symbol;
+    }
+  }
+
+  if (whole === 0 && closestFrac) {
+    return closestFrac;
+  }
+
+  if (whole > 0 && closestFrac) {
+    return `${whole} ${closestFrac}`;
+  }
+
+  // No close fraction match - format as decimal
+  if (remainder > 0.01) {
+    return quantity.toFixed(2).replace(/\.?0+$/, '');
+  }
+
+  return String(whole);
+}
+
+/**
+ * Decimal to display fraction (standalone function for use elsewhere)
+ */
+function decimalToFraction(decimal) {
+  return formatQuantityDisplay(decimal);
+}
+
+module.exports = {
+  parseIngredientString,
+  parseQuantity,
+  normalizeUnit,
+  formatIngredientDisplay,
+  formatQuantityDisplay,
+  decimalToFraction,
+  UNIT_MAP,
+  UNICODE_FRACTIONS,
+};

--- a/backend/tests/ingredientParser.test.js
+++ b/backend/tests/ingredientParser.test.js
@@ -1,0 +1,359 @@
+/**
+ * Unit tests for ingredient parsing utility
+ */
+
+const {
+  parseIngredientString,
+  parseQuantity,
+  normalizeUnit,
+  formatIngredientDisplay,
+  formatQuantityDisplay,
+  decimalToFraction,
+} = require('../src/utils/ingredientParser');
+
+describe('parseQuantity', () => {
+  describe('simple numbers', () => {
+    test('parses integers', () => {
+      expect(parseQuantity('2')).toBe(2);
+      expect(parseQuantity('10')).toBe(10);
+    });
+
+    test('parses decimals', () => {
+      expect(parseQuantity('2.5')).toBe(2.5);
+      expect(parseQuantity('0.25')).toBe(0.25);
+    });
+  });
+
+  describe('fractions', () => {
+    test('parses simple fractions', () => {
+      expect(parseQuantity('1/2')).toBe(0.5);
+      expect(parseQuantity('1/4')).toBe(0.25);
+      expect(parseQuantity('3/4')).toBe(0.75);
+    });
+
+    test('parses mixed numbers', () => {
+      expect(parseQuantity('1 1/2')).toBe(1.5);
+      expect(parseQuantity('2 1/4')).toBe(2.25);
+      expect(parseQuantity('3 3/4')).toBe(3.75);
+    });
+  });
+
+  describe('unicode fractions', () => {
+    test('parses unicode fractions', () => {
+      expect(parseQuantity('½')).toBe(0.5);
+      expect(parseQuantity('¼')).toBe(0.25);
+      expect(parseQuantity('¾')).toBe(0.75);
+      expect(parseQuantity('⅓')).toBeCloseTo(0.333, 2);
+      expect(parseQuantity('⅔')).toBeCloseTo(0.666, 2);
+    });
+
+    test('parses mixed unicode fractions', () => {
+      expect(parseQuantity('1½')).toBe(1.5);
+      expect(parseQuantity('2¼')).toBe(2.25);
+      expect(parseQuantity('1 ½')).toBe(1.5);
+      expect(parseQuantity('2 ¼')).toBe(2.25);
+    });
+  });
+
+  describe('ranges', () => {
+    test('parses dash ranges and averages', () => {
+      expect(parseQuantity('2-3')).toBe(2.5);
+      expect(parseQuantity('4-6')).toBe(5);
+    });
+
+    test('parses "to" ranges', () => {
+      expect(parseQuantity('2 to 3')).toBe(2.5);
+      expect(parseQuantity('4 to 6')).toBe(5);
+    });
+
+    test('parses "or" ranges', () => {
+      expect(parseQuantity('2 or 3')).toBe(2.5);
+    });
+  });
+
+  describe('edge cases', () => {
+    test('returns null for empty/null input', () => {
+      expect(parseQuantity(null)).toBeNull();
+      expect(parseQuantity(undefined)).toBeNull();
+      expect(parseQuantity('')).toBeNull();
+    });
+
+    test('handles whitespace', () => {
+      expect(parseQuantity('  2  ')).toBe(2);
+      expect(parseQuantity(' 1/2 ')).toBe(0.5);
+    });
+  });
+});
+
+describe('normalizeUnit', () => {
+  describe('volume units', () => {
+    test('normalizes teaspoon variants', () => {
+      expect(normalizeUnit('teaspoon')).toBe('tsp');
+      expect(normalizeUnit('teaspoons')).toBe('tsp');
+      expect(normalizeUnit('tsp')).toBe('tsp');
+      expect(normalizeUnit('t')).toBe('tsp');
+    });
+
+    test('normalizes tablespoon variants', () => {
+      expect(normalizeUnit('tablespoon')).toBe('tbsp');
+      expect(normalizeUnit('tablespoons')).toBe('tbsp');
+      expect(normalizeUnit('tbsp')).toBe('tbsp');
+      expect(normalizeUnit('Tbsp')).toBe('tbsp');
+      // Note: uppercase 'T' maps to tbsp but lowercase 't' maps to tsp
+      // This is intentional - T is a common abbreviation for tablespoon
+    });
+
+    test('normalizes cup variants', () => {
+      expect(normalizeUnit('cup')).toBe('cup');
+      expect(normalizeUnit('cups')).toBe('cup');
+      expect(normalizeUnit('c')).toBe('cup');
+    });
+  });
+
+  describe('weight units', () => {
+    test('normalizes pound variants', () => {
+      expect(normalizeUnit('pound')).toBe('lb');
+      expect(normalizeUnit('pounds')).toBe('lb');
+      expect(normalizeUnit('lb')).toBe('lb');
+      expect(normalizeUnit('lbs')).toBe('lb');
+    });
+
+    test('normalizes ounce variants', () => {
+      expect(normalizeUnit('ounce')).toBe('oz');
+      expect(normalizeUnit('ounces')).toBe('oz');
+      expect(normalizeUnit('oz')).toBe('oz');
+    });
+
+    test('normalizes gram variants', () => {
+      expect(normalizeUnit('gram')).toBe('g');
+      expect(normalizeUnit('grams')).toBe('g');
+      expect(normalizeUnit('g')).toBe('g');
+    });
+  });
+
+  describe('count units', () => {
+    test('normalizes container units', () => {
+      expect(normalizeUnit('can')).toBe('can');
+      expect(normalizeUnit('cans')).toBe('can');
+      expect(normalizeUnit('jar')).toBe('jar');
+      expect(normalizeUnit('jars')).toBe('jar');
+    });
+
+    test('normalizes produce units', () => {
+      expect(normalizeUnit('clove')).toBe('clove');
+      expect(normalizeUnit('cloves')).toBe('clove');
+      expect(normalizeUnit('bunch')).toBe('bunch');
+      expect(normalizeUnit('bunches')).toBe('bunch');
+    });
+  });
+
+  describe('non-unit words', () => {
+    test('returns null for descriptive words', () => {
+      expect(normalizeUnit('chopped')).toBeNull();
+      expect(normalizeUnit('fresh')).toBeNull();
+      expect(normalizeUnit('minced')).toBeNull();
+      expect(normalizeUnit('diced')).toBeNull();
+    });
+  });
+
+  describe('edge cases', () => {
+    test('returns null for empty/null input', () => {
+      expect(normalizeUnit(null)).toBeNull();
+      expect(normalizeUnit(undefined)).toBeNull();
+      expect(normalizeUnit('')).toBeNull();
+    });
+
+    test('is case-insensitive', () => {
+      expect(normalizeUnit('CUP')).toBe('cup');
+      expect(normalizeUnit('TABLESPOON')).toBe('tbsp');
+    });
+  });
+});
+
+describe('parseIngredientString', () => {
+  describe('standard ingredients', () => {
+    test('parses quantity + unit + ingredient', () => {
+      const result = parseIngredientString('2 cups flour');
+      expect(result.quantity).toBe(2);
+      expect(result.unit).toBe('cup');
+      expect(result.ingredient).toBe('flour');
+    });
+
+    test('parses with fractions', () => {
+      const result = parseIngredientString('1/2 tsp salt');
+      expect(result.quantity).toBe(0.5);
+      expect(result.unit).toBe('tsp');
+      expect(result.ingredient).toBe('salt');
+    });
+
+    test('parses unicode fractions', () => {
+      const result = parseIngredientString('½ cup milk');
+      expect(result.quantity).toBe(0.5);
+      expect(result.unit).toBe('cup');
+      expect(result.ingredient).toBe('milk');
+    });
+
+    test('parses mixed numbers', () => {
+      const result = parseIngredientString('1 1/2 cups sugar');
+      expect(result.quantity).toBe(1.5);
+      expect(result.unit).toBe('cup');
+      expect(result.ingredient).toBe('sugar');
+    });
+  });
+
+  describe('unitless ingredients', () => {
+    test('parses count ingredients', () => {
+      const result = parseIngredientString('2 eggs');
+      expect(result.quantity).toBe(2);
+      expect(result.unit).toBeNull();
+      expect(result.ingredient).toBe('eggs');
+    });
+
+    test('parses ingredients without quantity', () => {
+      const result = parseIngredientString('salt to taste');
+      expect(result.quantity).toBeNull();
+      expect(result.unit).toBeNull();
+      expect(result.ingredient).toBe('salt to taste');
+    });
+  });
+
+  describe('preparation notes', () => {
+    test('extracts comma-separated preparation', () => {
+      const result = parseIngredientString('2 cups flour, sifted');
+      expect(result.quantity).toBe(2);
+      expect(result.unit).toBe('cup');
+      expect(result.ingredient).toBe('flour');
+      expect(result.preparation).toBe('sifted');
+    });
+
+    test('extracts parenthetical notes', () => {
+      const result = parseIngredientString('1 cup butter (softened)');
+      expect(result.quantity).toBe(1);
+      expect(result.unit).toBe('cup');
+      expect(result.ingredient).toBe('butter');
+      expect(result.preparation).toBe('softened');
+    });
+  });
+
+  describe('multi-word ingredients', () => {
+    test('parses multi-word ingredient names', () => {
+      const result = parseIngredientString('1 lb ground beef');
+      expect(result.quantity).toBe(1);
+      expect(result.unit).toBe('lb');
+      expect(result.ingredient).toBe('ground beef');
+    });
+
+    test('parses descriptive ingredient names', () => {
+      const result = parseIngredientString('2 cups all-purpose flour');
+      expect(result.quantity).toBe(2);
+      expect(result.unit).toBe('cup');
+      expect(result.ingredient).toBe('all-purpose flour');
+    });
+  });
+
+  describe('edge cases', () => {
+    test('preserves raw text', () => {
+      const result = parseIngredientString('2 cups flour');
+      expect(result.rawText).toBe('2 cups flour');
+    });
+
+    test('handles empty input', () => {
+      const result = parseIngredientString('');
+      expect(result.rawText).toBe('');
+      expect(result.ingredient).toBe('');
+    });
+
+    test('handles null input', () => {
+      const result = parseIngredientString(null);
+      expect(result.rawText).toBe('');
+    });
+
+    test('sets sort order', () => {
+      const result = parseIngredientString('2 cups flour', 5);
+      expect(result.sortOrder).toBe(5);
+    });
+  });
+});
+
+describe('formatQuantityDisplay', () => {
+  test('formats whole numbers', () => {
+    expect(formatQuantityDisplay(2)).toBe('2');
+    expect(formatQuantityDisplay(10)).toBe('10');
+  });
+
+  test('formats common fractions as unicode', () => {
+    expect(formatQuantityDisplay(0.5)).toBe('½');
+    expect(formatQuantityDisplay(0.25)).toBe('¼');
+    expect(formatQuantityDisplay(0.75)).toBe('¾');
+  });
+
+  test('formats mixed numbers', () => {
+    expect(formatQuantityDisplay(1.5)).toBe('1 ½');
+    expect(formatQuantityDisplay(2.25)).toBe('2 ¼');
+    expect(formatQuantityDisplay(3.75)).toBe('3 ¾');
+  });
+
+  test('formats uncommon decimals', () => {
+    // Values not close to any common fraction get decimal format
+    // The threshold is 0.05, so values like 2.17 (close to 2.125=⅛) round to ⅛
+    // Testing with values far from any fraction
+    expect(formatQuantityDisplay(1.57)).toBe('1.57');
+    expect(formatQuantityDisplay(2.43)).toBe('2.43');
+  });
+});
+
+describe('formatIngredientDisplay', () => {
+  test('formats complete ingredient', () => {
+    const ingredient = {
+      quantity: 2,
+      unit: 'cup',
+      ingredient: 'flour',
+      rawText: '2 cups flour',
+    };
+    // Backend formatter returns lowercase ingredient name
+    expect(formatIngredientDisplay(ingredient)).toBe('2 cup flour');
+  });
+
+  test('formats unitless ingredient', () => {
+    const ingredient = {
+      quantity: 2,
+      unit: null,
+      ingredient: 'eggs',
+      rawText: '2 eggs',
+    };
+    // Backend formatter returns lowercase ingredient name
+    expect(formatIngredientDisplay(ingredient)).toBe('2 eggs');
+  });
+
+  test('falls back to raw text when no parsed data', () => {
+    const ingredient = {
+      quantity: null,
+      unit: null,
+      ingredient: 'salt to taste',
+      rawText: 'salt to taste',
+    };
+    expect(formatIngredientDisplay(ingredient)).toBe('salt to taste');
+  });
+
+  test('handles null ingredient', () => {
+    expect(formatIngredientDisplay(null)).toBe('');
+  });
+});
+
+describe('decimalToFraction', () => {
+  test('converts common fractions', () => {
+    expect(decimalToFraction(0.5)).toBe('½');
+    expect(decimalToFraction(0.25)).toBe('¼');
+    expect(decimalToFraction(0.75)).toBe('¾');
+  });
+
+  test('converts mixed numbers', () => {
+    expect(decimalToFraction(1.5)).toBe('1 ½');
+    expect(decimalToFraction(2.25)).toBe('2 ¼');
+  });
+
+  test('returns decimal for non-standard values', () => {
+    // 1.57 is not close to any common fraction
+    expect(decimalToFraction(1.57)).toBe('1.57');
+  });
+});

--- a/frontend/src/core/index.js
+++ b/frontend/src/core/index.js
@@ -15,6 +15,8 @@ export {
   formatQuantityWithUnit,
   parseIngredient,
   createIngredientKey,
+  formatIngredientDisplay,
+  formatScaledIngredient,
 } from './ingredients.js';
 
 // Category utilities

--- a/frontend/src/pages/RecipeDetailPage.jsx
+++ b/frontend/src/pages/RecipeDetailPage.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { recipes, shoppingLists } from '../services/api';
+import { formatScaledIngredient } from '../core';
 import Layout from '../components/Layout';
 import LoadingSpinner from '../components/LoadingSpinner';
 import Button from '../components/Button';
@@ -108,83 +109,28 @@ export default function RecipeDetailPage() {
     }
   };
 
-  // Format ingredient quantity for display
+  // Format ingredient for display using core module
+  // Returns either a string or JSX element (for scaled ingredients with original)
   const formatQuantity = (ingredient) => {
-    if (!ingredient.quantity) {
-      return ingredient.rawText;
-    }
+    const { display, scaled, originalDisplay } = formatScaledIngredient(ingredient, true);
 
-    const qty = ingredient.quantity;
-    let displayQty = String(qty);
-
-    // Convert decimals to fractions
-    const fractionMap = {
-      0.125: '⅛',
-      0.25: '¼',
-      0.333: '⅓',
-      0.375: '⅜',
-      0.5: '½',
-      0.625: '⅝',
-      0.666: '⅔',
-      0.75: '¾',
-      0.875: '⅞',
-    };
-
-    const whole = Math.floor(qty);
-    const fraction = qty - whole;
-
-    for (const [decimal, frac] of Object.entries(fractionMap)) {
-      if (Math.abs(fraction - parseFloat(decimal)) < 0.01) {
-        displayQty = whole > 0 ? `${whole} ${frac}` : frac;
-        break;
-      }
-    }
-
-    // If not converted to fraction, format decimal
-    if (displayQty === String(qty) && fraction > 0.01) {
-      displayQty = qty.toFixed(2);
-    } else if (fraction < 0.01) {
-      displayQty = String(whole);
-    }
-
-    const unit = ingredient.unit || '';
-    const name = ingredient.ingredientName || '';
-
-    // Show original if scaled
-    if (ingredient.originalQuantity && Math.abs(ingredient.originalQuantity - qty) > 0.01) {
-      const originalQty = ingredient.originalQuantity;
-      let originalDisplay = String(originalQty);
-
-      const originalWhole = Math.floor(originalQty);
-      const originalFraction = originalQty - originalWhole;
-
-      for (const [decimal, frac] of Object.entries(fractionMap)) {
-        if (Math.abs(originalFraction - parseFloat(decimal)) < 0.01) {
-          originalDisplay = originalWhole > 0 ? `${originalWhole} ${frac}` : frac;
-          break;
-        }
-      }
-
-      if (originalDisplay === String(originalQty) && originalFraction > 0.01) {
-        originalDisplay = originalQty.toFixed(2);
-      } else if (originalFraction < 0.01) {
-        originalDisplay = String(originalWhole);
-      }
+    if (scaled && originalDisplay) {
+      // Get the parts for styled display
+      const name = ingredient.ingredientName || ingredient.ingredient || '';
+      const capitalizedName = name ? name.charAt(0).toUpperCase() + name.slice(1) : '';
 
       return (
         <span>
           <span className="font-semibold text-primary-700">
-            {displayQty} {unit}
+            {originalDisplay ? display.replace(capitalizedName, '').trim() : display}
           </span>{' '}
-          {name}
-          <span className="text-xs text-gray-500 ml-2">
-            (originally {originalDisplay} {unit})
-          </span>
+          {capitalizedName}
+          <span className="text-xs text-gray-500 ml-2">(originally {originalDisplay})</span>
         </span>
       );
     }
 
-    return `${displayQty} ${unit} ${name}`.trim();
+    return display;
   };
 
   const handleDelete = async () => {


### PR DESCRIPTION
## Summary
- Add robust backend ingredient parser (`backend/src/utils/ingredientParser.js`) with comprehensive parsing support:
  - Unicode fractions (½, ¼, ⅓, ¾, ⅛, ⅜, ⅝, ⅞, etc.)
  - Mixed numbers (1 1/2, 2 ½)
  - Quantity ranges (2-3 → averages to 2.5)
  - Unit normalization (tablespoon → tbsp, pounds → lb, etc.)
  - Preparation notes extraction (e.g., "diced", "minced")
- Add `formatIngredientDisplay()` and `formatScaledIngredient()` to frontend core module for consistent ingredient formatting
- Refactor `RecipeDetailPage` to use core module formatting (reduced 77 lines to 11)
- Add 47 backend tests for ingredient parsing edge cases
- Add 15 frontend tests for display formatting functions

## Test plan
- [x] Backend tests pass (47 tests in `ingredientParser.test.js`)
- [x] Frontend tests pass (64 tests including 15 new tests in `core.test.mjs`)
- [x] Frontend build succeeds
- [ ] Manual testing: verify recipe detail page displays ingredients correctly with fractions
- [ ] Manual testing: verify scaled ingredients show original quantities

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)